### PR TITLE
Slots and alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,3 @@ $ polymer test --skip-plugin junit-reporter
 Your application is already set up to be tested via [web-component-tester](https://github.com/Polymer/web-component-tester). Run `polymer test` to run your application's test suite locally.
 
 ## TODO
-
-- Color schemes
-- Alignment (?)

--- a/bower.json
+++ b/bower.json
@@ -1,29 +1,31 @@
 {
-  "name": "kwc-nav",
-  "description": "Display navigation links within the view header, to select sub-views.",
-  "main": "kwc-nav.html",
-  "dependencies": {
-    "polymer": "Polymer/polymer#^1.9.0",
-    "kwc-nav-item": "git@github.com:KanoComponents/kwc-nav-item.git",
-    "iron-flex-layout": "^2.0.0"
-  },
-  "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
-    "web-component-tester": "Polymer/web-component-tester#^6.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
-    "chai": "^4.1.2"
-  },
-  "resolutions": {
-      "chai": "^4.1.2",
-      "iron-component-page": "^1.0.0",
-      "iron-icon": "^1.0.0",
-      "polymer": "1.9 - 2",
-      "webcomponentsjs": "^0.7.24",
-      "iron-flex-layout": "1 - 2",
-      "iron-doc-viewer": "^1.0.1",
-      "iron-location": "^0.8.0",
-      "paper-button": "^1.0.0",
-      "iron-iconset-svg": "^1.0.0"
+    "name": "kwc-nav",
+    "description": "Display navigation links within the view header, to select sub-views.",
+    "main": "kwc-nav.html",
+    "dependencies": {
+        "polymer": "Polymer/polymer#^1.9.0",
+        "iron-flex-layout": "^2.0.0",
+        "iron-selector": "^2.0.0"
+    },
+    "devDependencies": {
+        "kwc-nav-item": "git@github.com:KanoComponents/kwc-nav-item.git",
+        "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+        "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
+        "web-component-tester": "Polymer/web-component-tester#^6.0.0",
+        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
+        "chai": "^4.1.2"
+    },
+    "resolutions": {
+        "chai": "^4.1.2",
+        "iron-component-page": "^1.0.0",
+        "iron-icon": "^1.0.0",
+        "polymer": "1.9 - 2",
+        "webcomponentsjs": "^0.7.24",
+        "iron-flex-layout": "1 - 2",
+        "iron-doc-viewer": "^1.0.1",
+        "iron-location": "^0.8.0",
+        "paper-button": "^1.0.0",
+        "iron-iconset-svg": "^1.0.0",
+        "iron-selector": "^2.0.0"
     }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -10,6 +10,7 @@
 
     <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
     <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+    <link rel="import" href="../../kwc-nav-item/kwc-nav-item.html">
     <link rel="import" href="../kwc-nav.html">
 
     <custom-style>
@@ -18,26 +19,96 @@
 </head>
 <body>
     <div class="vertical-section-container centered">
-        <h3>Basic kwc-nav demo</h3>
+        <h3>Navigation with caret</h3>
         <demo-snippet>
             <template>
-                <div style="background: #cacaca">
-                    <kwc-nav id="kwc-nav"
-                             has-caret>
-                             </kwc-nav>
-                </div>
-                <script type="text/javascript">
-                document.addEventListener('WebComponentsReady', function() {
-                    var nav = document.getElementById('kwc-nav');
-                    var navItems = [
-                        { id:"item-1", label: "Item 1", iconId: "challenges" },
-                        { id:"item-2", label: "Item 2", iconId: "medals" },
-                        { id:"item-3", label: "Item 3" }
-                    ];
-                    nav.set('navItems', navItems);
-                    nav.set('activeItemId', navItems[1].id);
-                });
-                </script>
+                <style media="screen">
+                    .kwc-nav-example { background: #394148; }
+                </style>
+                <kwc-nav class="kwc-nav-example" has-caret selected="item-2" attr-for-selected="name">
+                    <kwc-nav-item slot="navigation" name="item-1" icon-id="challenges">
+                        <a href="#">Item 1</a>
+                    </kwc-nav-item>
+                    <kwc-nav-item slot="navigation" name="item-2" icon-id="medals">
+                        <button>Item 2</button>
+                    </kwc-nav-item>
+                    <kwc-nav-item slot="navigation" name="item-3">Item 3</kwc-nav-item>
+                </kwc-nav>
+            </template>
+        </demo-snippet>
+
+        <h3>Navigation without caret and custom items</h3>
+        <demo-snippet>
+            <template>
+                <style>
+                    .test-selected { font-weight: bold; }
+                    a { padding: 10px; }
+                </style>
+                <kwc-nav selected="0" selected-class="test-selected">
+                    <div slot="navigation">
+                        <a href="#">Item 1</a>
+                    </div>
+                    <div slot="navigation">
+                        <a href="#">Item 2</a>
+                    </div>
+                    <div slot="navigation">
+                        <a href="#">Item 3</a>
+                    </div>
+                </kwc-nav>
+            </template>
+        </demo-snippet>
+
+        <h3>Alignment examples</h3>
+        <demo-snippet>
+            <template>
+                <style media="screen">
+                    .kwc-nav-example { background: #394148; }
+                </style>
+                <h4>Start</h4>
+                <kwc-nav class="kwc-nav-example" alignment="start">
+                    <kwc-nav-item slot="navigation" name="item-1">
+                        Item 1
+                    </kwc-nav-item>
+                    <kwc-nav-item slot="navigation" name="item-2">
+                        Item 2
+                    </kwc-nav-item>
+                </kwc-nav>
+                <h4>Center</h4>
+                <kwc-nav class="kwc-nav-example" alignment="center">
+                    <kwc-nav-item slot="navigation" name="item-1">
+                        Item 1
+                    </kwc-nav-item>
+                    <kwc-nav-item slot="navigation" name="item-2">
+                        Item 2
+                    </kwc-nav-item>
+                </kwc-nav>
+                <h4>End</h4>
+                <kwc-nav class="kwc-nav-example" alignment="end">
+                    <kwc-nav-item slot="navigation" name="item-1">
+                        Item 1
+                    </kwc-nav-item>
+                    <kwc-nav-item slot="navigation" name="item-2">
+                        Item 2
+                    </kwc-nav-item>
+                </kwc-nav>
+                <h4>Space Around</h4>
+                <kwc-nav class="kwc-nav-example" alignment="space-around">
+                    <kwc-nav-item slot="navigation" name="item-1">
+                        Item 1
+                    </kwc-nav-item>
+                    <kwc-nav-item slot="navigation" name="item-2">
+                        Item 2
+                    </kwc-nav-item>
+                </kwc-nav>
+                <h4>Space Between</h4>
+                <kwc-nav class="kwc-nav-example" alignment="space-between">
+                    <kwc-nav-item slot="navigation" name="item-1">
+                        Item 1
+                    </kwc-nav-item>
+                    <kwc-nav-item slot="navigation" name="item-2">
+                        Item 2
+                    </kwc-nav-item>
+                </kwc-nav>
             </template>
         </demo-snippet>
     </div>

--- a/kwc-nav.html
+++ b/kwc-nav.html
@@ -75,33 +75,49 @@ Display navigation links within the view header, to select sub-views.
                 Polymer.IronSelectableBehavior
             ],
             properties: {
-                /** Flags if navigation should display a caret */
+                /**
+                 * Flags if navigation should display a caret
+                 * @type {Boolean}
+                 */
                 hasCaret: {
                     type: Boolean,
                     value: false
                 },
-                /** Defines how to align navigation items accordingly */
+                /**
+                 * Defines how to align navigation items accordingly
+                 * @type {String}
+                 */
                 alignment: {
                     type: String,
                     value: 'start'
                 },
+                /**
+                 * Override `IronSelectableBehavior`'s property just to make it
+                 * clear the api for changing the `selectedClass` can be used
+                 * @type {String}
+                 */
                 selectedClass: {
                     type: String,
                     value: 'iron-selected'
                 },
-                /** Computed class to apply alignment on navigation items */
+                /**
+                 * Computed class to apply alignment on navigation items
+                 * @type {String}
+                 */
                 _alignmentClass: {
                     type: String,
                     computed: '_computeAlignmentClass(alignment)'
                 },
                 /**
                  * Keeps track of the caret's current position
+                 * @type {Number}
                  */
                 _caretPosition: {
                     type: Number
                 },
                 /**
                  * How much the caret should "drift" before reaches the target
+                 * @type {Number}
                  */
                 _overRun: {
                     type: Number,
@@ -127,8 +143,8 @@ Display navigation links within the view header, to select sub-views.
             },
             /**
              * Gets the element from navigation items given the item id.
-             * @param {String} itemId Item id.
-             * @return {HTMLElement}
+             * @param {String} selector CSS selector
+             * @return {HTMLElement} HTML Element that matches selector
              */
             _getTargetElement (selector) {
                 return Polymer.dom(this).querySelector(selector);
@@ -195,6 +211,12 @@ Display navigation links within the view header, to select sub-views.
                     }, 10);
                 });
             },
+            /**
+             * Computes the alignment class to be applied to the navigation
+             * based on `alignment` property
+             * @param {String} alignment What is the navigation alignment
+             * @return {String} Which class to append to navigation
+             */
             _computeAlignmentClass (alignment) {
                 let alignmentClass = 'justify-start';
                 switch (alignment) {

--- a/kwc-nav.html
+++ b/kwc-nav.html
@@ -1,6 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
-<link rel="import" href="../kwc-nav-item/kwc-nav-item.html">
+<link rel="import" href="../iron-selector/iron-selector.html">
 
 <!--
 `kwc-nav`
@@ -15,9 +14,8 @@ Display navigation links within the view header, to select sub-views.
             :host {
                 display: block;
             }
-            :host .nav-items {
+            .nav-items {
                 @apply --layout-horizontal;
-                @apply --layout-justify-center;
                 font-size: 20px;
                 list-style: none;
                 list-style: none;
@@ -25,14 +23,14 @@ Display navigation links within the view header, to select sub-views.
                 padding: 0;
                 position: relative;
             }
-            :host .caret-container {
+            .caret-container {
                 width: 100%;
             }
-            :host #caret {
+            #caret {
                 display: none;
                 position: relative;
             }
-            :host #caret::after {
+            #caret::after {
                 background-color: #ffffff;
                 border-radius: 3px 0 0 0;
                 content: "";
@@ -44,57 +42,57 @@ Display navigation links within the view header, to select sub-views.
                 transform: rotate(45deg);
                 width: 12px;
             }
+            .nav-items.justify-start {
+                @apply --layout-start-justified;
+            }
+            .nav-items.justify-end {
+                @apply --layout-end-justified;
+            }
+            .nav-items.justify-center {
+                @apply --layout-center-center;
+            }
+            .nav-items.justify-space-between {
+                @apply --layout-justified;
+            }
+            .nav-items.justify-space-around {
+                @apply --layout-around-justified;
+            }
         </style>
-        <nav class="navigation">
-            <ul class="nav-items">
-                <template id="items" is="dom-repeat" items="[[navItems]]" on-dom-change="_moveCaret">
-                    <li>
-                        <kwc-nav-item id="[[item.id]]"
-                                      label="[[item.label]]"
-                                      icon-id="[[item.iconId]]"
-                                      active="[[_isActive(item, activeItemId)]]"
-                                      on-tap="_onTap">
-                                      </kwc-nav-item>
-                    </li>
-                </template>
-            </ul>
-            <template is="dom-if" if="[[hasCaret]]">
-                <div class="caret-container">
-                    <div id="caret"></div>
-                </div>
-            </template>
-        </nav>
+        <div class$="nav-items [[_alignmentClass]]">
+            <slot name="navigation"></slot>
+        </div>
+        <template is="dom-if" if="[[hasCaret]]">
+            <div class="caret-container">
+                <div id="caret"></div>
+            </div>
+        </template>
     </template>
 
     <script>
         Polymer({
             is: 'kwc-nav',
+            behaviors: [
+                Polymer.IronSelectableBehavior
+            ],
             properties: {
                 /** Flags if navigation should display a caret */
                 hasCaret: {
                     type: Boolean,
                     value: false
                 },
-                /**
-                 * Array of objects representing navigation items. This object
-                 * should follow the format:
-                 * {
-                 *     id: { type: String, required: true },
-                 *     label: { type: String, required: true },
-                 *     iconId: { type: String }
-                 * }
-                 */
-                navItems: {
-                    type: Array,
-                    value: null
-                },
-                /**
-                 * Keeps track of the currently active navigation item on
-                 * `navItems`
-                 */
-                activeItemId: {
+                /** Defines how to align navigation items accordingly */
+                alignment: {
                     type: String,
-                    value: null
+                    value: 'start'
+                },
+                selectedClass: {
+                    type: String,
+                    value: 'iron-selected'
+                },
+                /** Computed class to apply alignment on navigation items */
+                _alignmentClass: {
+                    type: String,
+                    computed: '_computeAlignmentClass(alignment)'
                 },
                 /**
                  * Keeps track of the caret's current position
@@ -111,38 +109,8 @@ Display navigation links within the view header, to select sub-views.
                 }
             },
             observers: [
-                 '_moveCaret(activeItemId)'
+                 '_moveCaret(selected)'
             ],
-            /**
-             * Checks if the given navigation item is the one currently active.
-             * @param {Object} navItem Navigation item.
-             * @param {String} activeItemId Id of the currently active navigation
-             *     item.
-             * @return {Boolean} Flag if item is active or not.
-             */
-            _isActive (navItem, activeItemId) {
-                if (!navItem || !activeItemId) {
-                    return false;
-                }
-                return navItem.id === activeItemId;
-            },
-            /**
-             * Fired when a navigation item is clicked.
-             * @event navigated
-             * @param {String} activeItem Item id related to the clicked
-             *     navigation item.
-             */
-            /**
-             * Handles tap events on navigation items.
-             * @param {Event} e Polymer `tap` event.
-             */
-            _onTap (e) {
-                if (e.model && e.model.item) {
-                    let activeItem = e.model.item.id;
-                    this.set('activeItemId', activeItem);
-                    this.fire('navigated', activeItem);
-                }
-            },
             /**
              * Calculates the next position the caret should be basen on the
              * current `activeItemId`.
@@ -162,8 +130,8 @@ Display navigation links within the view header, to select sub-views.
              * @param {String} itemId Item id.
              * @return {HTMLElement}
              */
-            _getTargetElement (itemId) {
-                return this.$$(`#${itemId}`);
+            _getTargetElement (selector) {
+                return Polymer.dom(this).querySelector(selector);
             },
             /**
              * Animates caret from one position to another.
@@ -201,7 +169,7 @@ Display navigation links within the view header, to select sub-views.
                         return resolve(false);
                     }
                     this.debounce('move-caret', () => {
-                        let targetElement = this._getTargetElement(this.activeItemId),
+                        let targetElement = this._getTargetElement(`.${this.selectedClass}`),
                             targetOffset = this._calculateTargetOffset(targetElement),
                             currentOffset = this._caretPosition || 0;
 
@@ -226,6 +194,31 @@ Display navigation links within the view header, to select sub-views.
                         };
                     }, 10);
                 });
+            },
+            _computeAlignmentClass (alignment) {
+                let alignmentClass = 'justify-start';
+                switch (alignment) {
+                    case 'start':
+                        alignmentClass = 'justify-start';
+                        break;
+                    case 'end':
+                        alignmentClass = 'justify-end';
+                        break;
+                    case 'center':
+                        alignmentClass = 'justify-center';
+                        break;
+                    case 'space-between':
+                        alignmentClass = 'justify-space-between';
+                        break;
+                    case 'space-around':
+                        alignmentClass = 'justify-space-around';
+                        break;
+                    case 'space-evenly':
+                        alignmentClass = 'justify-space-evenly';
+                        break;
+                    break;
+                }
+                return alignmentClass;
             }
         });
     </script>

--- a/test/kwc-nav_test.html
+++ b/test/kwc-nav_test.html
@@ -149,7 +149,8 @@
                 });
                 test('has caret on DOM', (done) => {
                     flush(() => {
-                        let caret = Polymer.dom(element.root).querySelector('#caret');
+                        let caret = Polymer.dom(element.root)
+                            .querySelector('#caret');
                         assert.exists(caret);
                         done();
                     });

--- a/test/kwc-nav_test.html
+++ b/test/kwc-nav_test.html
@@ -8,13 +8,20 @@
 
         <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
         <script src="../../web-component-tester/browser.js"></script>
-
+        <link rel="import" href="../../kwc-nav-item/kwc-nav-item.html">
         <link rel="import" href="../kwc-nav.html">
     </head>
     <body>
         <test-fixture id="basic">
             <template>
-                <kwc-nav nav-items="[[items]]"></kwc-nav>
+                <kwc-nav attr-for-selected="name">
+                    <kwc-nav-item slot="navigation" name="item-1">
+                        Item 1
+                    </kwc-nav-item>
+                    <kwc-nav-item slot="navigation" name="item-2">
+                        Item 2
+                    </kwc-nav-item>
+                </kwc-nav>
             </template>
         </test-fixture>
         <test-fixture id="empty">
@@ -24,33 +31,48 @@
         </test-fixture>
         <test-fixture id="active-item">
             <template>
-                    <kwc-nav nav-items="[[items]]"
-                             active-item-id="item-1">
-                    </kwc-nav>
+                <kwc-nav attr-for-selected="name">
+                    <kwc-nav-item slot="navigation" name="item-1">
+                        Item 1
+                    </kwc-nav-item>
+                    <kwc-nav-item slot="navigation" name="item-2">
+                        Item 2
+                    </kwc-nav-item>
+                </kwc-nav>
+            </template>
+        </test-fixture>
+        <test-fixture id="active-item-programatically">
+            <template>
+                <kwc-nav attr-for-selected="name">
+                    <kwc-nav-item slot="navigation" name="item-1">
+                        Item 1
+                    </kwc-nav-item>
+                    <kwc-nav-item slot="navigation" name="item-2">
+                        Item 2
+                    </kwc-nav-item>
+                </kwc-nav>
             </template>
         </test-fixture>
         <test-fixture id="caret">
             <template>
-                    <kwc-nav nav-items="[[items]]"
-                             active-item-id="item-2"
-                             has-caret>
-                    </kwc-nav>
+                <kwc-nav has-caret attr-for-selected="name">
+                    <kwc-nav-item slot="navigation" name="item-1">
+                        Item 1
+                    </kwc-nav-item>
+                    <kwc-nav-item slot="navigation" name="item-2">
+                        Item 2
+                    </kwc-nav-item>
+                </kwc-nav>
             </template>
         </test-fixture>
         <script>
-            let items = [
-                    { id:"item-1", label: "Item 1", iconId: "challenges" },
-                    { id:"item-2", label: "Item 2", iconId: "medals" },
-                    { id:"item-3", label: "Item 3" }
-                ],
-                activeItemId1 = items[0].id,
-                activeItemId2 = items[1].id;
+            let selectedItem1 = 'item-1',
+                selectedItem2 = 'item-2';
 
             suite('basic', () => {
                 let element;
                 setup(() => {
                     element = fixture('basic');
-                    element.set('navItems', items);
                 })
                 test('instantiating the element works', () => {
                     assert.equal(element.is, 'kwc-nav');
@@ -67,27 +89,7 @@
                     });
                 });
                 test('no active item by default', () => {
-                    let anyActive = element.navItems.some((el) => {
-                        return element._isActive(el, element.activeItemId);
-                    });
-                    assert.equal(anyActive, false);
-                    assert.equal(element.activeItemId, null);
-                });
-                test('navigation items set properly', () => {
-                    assert.equal(element.navItems, items);
-                });
-                test('navigation items set properly on DOM', (done) => {
-                    flush(() => {
-                        let navItemsElements = Polymer.dom(element.root)
-                                .querySelectorAll('kwc-nav-item');
-                        /** Check length */
-                        assert.equal(navItemsElements.length, items.length);
-                        /** Check order */
-                        assert.equal(navItemsElements[0].id, items[0].id);
-                        assert.equal(navItemsElements[1].id, items[1].id);
-                        assert.equal(navItemsElements[2].id, items[2].id);
-                        done();
-                    });
+                    assert.notExists(element.selected);
                 });
             });
 
@@ -96,53 +98,43 @@
                 setup(function() {
                     element = fixture('empty');
                 });
-                test('no navigation items', () => {
-                    assert.equal(element.navItems, null);
-                });
-                test('no navigation items on DOM', (done) => {
-                    flush(() => {
-                        let navItemsElements = Polymer.dom(element.root)
-                                .querySelectorAll('kwc-nav-item');
-                        assert.equal(navItemsElements.length, 0);
-                        done();
-                    });
-                });
             });
 
             suite('active item', () => {
                 let element;
                 setup(() => {
                     element = fixture('active-item');
-                    element.set('navItems', items);
-                    element.set('activeItemId', activeItemId1);
-                })
-                test('active item set properly', () => {
-                    let isActive = element._isActive(
-                        element.navItems[0], activeItemId1
-                    );
-                    assert.equal(isActive, true);
-                    assert.equal(element.activeItemId, activeItemId1);
+                    element.set('selected', selectedItem2);
                 });
-                test('changing active item programatically', () => {
-                    element.set('activeItemId', activeItemId2);
-                    assert.equal(element.activeItemId, activeItemId2);
-                    let isActive = element._isActive(
-                        element.navItems[1], activeItemId2
-                    );
-                    assert.equal(isActive, true);
+                test('active item set properly', () => {
+                    assert.equal(element.selected, selectedItem2);
                 });
                 test('tapping item changes active item', (done) => {
                     flush(() => {
                         let navItems = Polymer.dom(element.root)
-                                .querySelectorAll('kwc-nav-item');
-                        navItems[2].click();
-                        assert.equal(element.activeItemId, items[2].id);
+                            .querySelector('.nav-items')
+                            .querySelectorAll('kwc-nav-item');
                         navItems[1].click();
-                        assert.equal(element.activeItemId, items[1].id);
+                        assert.equal(element.selected, selectedItem2);
                         navItems[0].click();
-                        assert.equal(element.activeItemId, items[0].id);
+                        assert.equal(element.selected, selectedItem1);
                         done();
                     });
+                });
+            });
+
+            suite('active item programatically', () => {
+                let element;
+                setup(() => {
+                    element = fixture('active-item');
+                    element.set('selected', selectedItem1);
+                });
+                test('active item set properly', () => {
+                    assert.equal(element.selected, selectedItem1);
+                });
+                test('changing active item programatically', () => {
+                    element.set('selected', selectedItem2);
+                    assert.equal(element.selected, selectedItem2);
                 });
             });
 
@@ -150,8 +142,7 @@
                 let element;
                 setup(() => {
                     element = fixture('caret');
-                    element.set('navItems', items);
-                    element.set('activeItemId', activeItemId1);
+                    element.set('selected', selectedItem2);
                 })
                 test('has caret', () => {
                     assert.equal(element.hasCaret, true);


### PR DESCRIPTION
This PR's demo and tests depends on: https://github.com/KanoComponents/kwc-nav-item/pull/10

- Using slots instead of an array of objects
- Alignment properties
- Improved documentation and tests

TO FIX:
- Tests not passing on Safari because `animate` API apparently is not there.