### PR TITLE
Animate on safari

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -11,6 +11,7 @@
     <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
     <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
     <link rel="import" href="../../kwc-nav-item/kwc-nav-item.html">
+    <link rel="import" href="../../kwc-nav-item/kwc-nav-button.html">
     <link rel="import" href="../kwc-nav.html">
 
     <custom-style>
@@ -33,6 +34,21 @@
                         <button>Item 2</button>
                     </kwc-nav-item>
                     <kwc-nav-item slot="navigation" name="item-3">Item 3</kwc-nav-item>
+                </kwc-nav>
+            </template>
+        </demo-snippet>
+
+        <h3>Sub navigation with buttons</h3>
+        <demo-snippet>
+            <template>
+                <kwc-nav selected="item-2" attr-for-selected="name">
+                    <kwc-nav-button slot="navigation" name="item-1" icon-id="challenges">
+                        <a href="#">Item 1</a>
+                    </kwc-nav-button>
+                    <kwc-nav-button slot="navigation" name="item-2" icon-id="medals">
+                        <button>Item 2</button>
+                    </kwc-nav-button>
+                    <kwc-nav-button slot="navigation" name="item-3">Item 3</kwc-nav-button>
                 </kwc-nav>
             </template>
         </demo-snippet>

--- a/kwc-nav.html
+++ b/kwc-nav.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-selector/iron-selector.html">
+<link rel="import" href="../iron-selector/iron-selectable.html">
 
 <!--
 `kwc-nav`
@@ -155,22 +155,32 @@ Display navigation links within the view header, to select sub-views.
              * @param {Number} currentPosition Current caret's position.
              * @param {Number} targetPosition Position the caret should end the
              *     animation at.
-             * @return {Object} Animation object.
+             * @return {Promise} Animation promise.
              */
             _animateCaret (caret, currentPosition, targetPosition) {
-                let overRun = targetPosition > currentPosition ? this._overRun : -this._overRun;
-                return caret.animate([
-                        { offset: 0, transform: `translateX(${currentPosition}px)` },
-                        { offset: 0.8, transform: `translateX(${targetPosition+overRun}px)` },
-                        { offset: 1, transform: `translateX(${targetPosition}px)` },
-                    ],
-                    {
-                        duration: 250,
-                        easing: 'cubic-bezier(0.390, 0.575, 0.565, 1.000)',
-                        fill: 'forwards',
-                        iterations: 1
+                return new Promise((resolve, reject) => {
+                    if ('animate' in caret) {
+                        let overRun = targetPosition > currentPosition ? this._overRun : -this._overRun,
+                            animation = caret.animate([
+                                { offset: 0, transform: `translateX(${currentPosition}px)` },
+                                { offset: 0.8, transform: `translateX(${targetPosition+overRun}px)` },
+                                { offset: 1, transform: `translateX(${targetPosition}px)` },
+                            ],
+                            {
+                                duration: 250,
+                                easing: 'cubic-bezier(0.390, 0.575, 0.565, 1.000)',
+                                fill: 'forwards',
+                                iterations: 1
+                            }
+                        );
+                        animation.onfinish = () => {
+                            resolve();
+                        }
+                    } else {
+                        caret.style.transform = `translateX(${targetPosition}px)`;
+                        resolve();
                     }
-                );
+                });
             },
             /**
              * Moves caret to the new target position. Triggered when the
@@ -178,7 +188,7 @@ Display navigation links within the view header, to select sub-views.
              * changed.
              * @return {Boolean} Flags if caret was moved or not.
              */
-            _moveCaret () {
+            _moveCaret (selected) {
                 return new Promise((resolve, reject) => {
                     /** Skip this entirely if caret is disabled */
                     if (!this.hasCaret) {
@@ -193,21 +203,22 @@ Display navigation links within the view header, to select sub-views.
                             return resolve(false);
                         }
 
-                        let caret = this.$$('#caret'),
+                        let caret = this.$$('#caret');
                             animation = this._animateCaret(
                                 caret, currentOffset, targetOffset
                             );
-                        animation.onfinish = () => {
+
+                        animation.then(() => {
                             this.set('_caretPosition', targetOffset)
                             /**
-                             * The caret starts hidden by default so after animating
-                             * it to the initial position, it has to be displayed
-                             */
+                            * The caret starts hidden by default so after animating
+                            * it to the initial position, it has to be displayed
+                            */
                             if (!caret.style.display) {
                                 caret.style.display = 'block';
                             }
                             resolve(true);
-                        };
+                        });
                     }, 10);
                 });
             },


### PR DESCRIPTION
Do not use `animate` on Safari, instead fallback to no animation.
Plus add some demo for the "sub nav" with the `kwc-nav-button`.