### PR TITLE
Hide caret if target selection doesn't exist

### DIFF
--- a/kwc-nav.html
+++ b/kwc-nav.html
@@ -239,6 +239,11 @@ Display navigation links within the view header, to select sub-views.
                                 caret, currentOffset, targetOffset
                             );
 
+                        if (!targetElement) {
+                            this.toggleClass('visible', false, caret);
+                            this.set('_caretPosition', -1);
+                            return resolve(false);
+                        }
                         animation.then(() => {
                             this.set('_caretPosition', targetOffset)
                             /**


### PR DESCRIPTION
Sometimes the user is able to be in a page that doesn't exist on the `kwc-nav` and that was causing the caret to be displaced. This PR will make the caret hidden if the current page doesn't exist on `kwc-nav`.