### PR TITLE
Adjust caret position

### DIFF
--- a/kwc-nav.html
+++ b/kwc-nav.html
@@ -23,7 +23,7 @@ Display navigation links within the view header, to select sub-views.
                 padding: 0;
                 position: relative;
             }
-            .nav-items ::slotted(*) {
+            .nav-items ::slotted(*:not(:last-child)) {
                 margin-right: 16px;
             }
             .caret-container {
@@ -167,10 +167,11 @@ Display navigation links within the view header, to select sub-views.
              *     parent, representing the center of the `targetElement`
              */
             _calculateTargetOffset (targetElement) {
+                let caretWidth = 12;
                 if (!targetElement) {
                     return 0;
                 }
-                return targetElement.offsetLeft + (targetElement.offsetWidth/2);
+                return targetElement.offsetLeft + (targetElement.offsetWidth / 2) - (caretWidth / 2);
             },
             /**
              * Gets the element from navigation items given the item id.


### PR DESCRIPTION
Take the width of the caret into account when positioning it in the center of the nav item to allow this to be properly centered when the nav item doesn't have a label, but an icon only.

Also removes the margin on the last nav item.

Part of the changes for this Trello card: https://trello.com/c/Duf5kL2m