### PR TITLE
Constrain caret width

### DIFF
--- a/kwc-nav.html
+++ b/kwc-nav.html
@@ -33,6 +33,7 @@ Display navigation links within the view header, to select sub-views.
             #caret {
                 display: none;
                 position: relative;
+                width: 24px;
             }
             #caret::after {
                 background-color: #ffffff;


### PR DESCRIPTION
This should prevent pushing the page width larger when selecting items close to the right border.